### PR TITLE
Required JSON annotations for discovery

### DIFF
--- a/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/analytics/MailThreadSparkJobBuilder.java
+++ b/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/analytics/MailThreadSparkJobBuilder.java
@@ -1,8 +1,11 @@
 package com.lucidworks.searchhub.analytics;
 
+import com.lucidworks.apollo.Name;
 import com.lucidworks.spark.job.SparkJob;
 import com.lucidworks.spark.job.SparkJobBuilder;
 
+
+@Name("mail-threading")
 public class MailThreadSparkJobBuilder implements SparkJobBuilder<MailThreadSparkJobConfig> {
   @Override
   public SparkJob<?, MailThreadSparkJobConfig> buildSparkJob(String jobId, MailThreadSparkJobConfig config) {

--- a/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/analytics/MailThreadSparkJobConfig.java
+++ b/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/analytics/MailThreadSparkJobConfig.java
@@ -1,11 +1,16 @@
 package com.lucidworks.searchhub.analytics;
 
 import com.lucidworks.apollo.spark.SparkJobConfig;
+import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
+import org.codehaus.jackson.annotate.JsonTypeName;
 
+
+@JsonTypeName("mail-threading")
 public class MailThreadSparkJobConfig extends SparkJobConfig {
   public static final String TYPE = "mail_threading";
 
+  @JsonCreator
   public MailThreadSparkJobConfig(@JsonProperty("id") String id) {
     super(id, TYPE);
   }


### PR DESCRIPTION
This is why I had to use a "type": "script" job!  It wasn't finding the job class without being able to json serialize the config.
