### PR TITLE
Lucidfind 378 modify template view new2

### DIFF
--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -12,6 +12,6 @@
   <h6>Sent from:<br><field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>  :  <field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
-    <field ng-if="doc.body" value="doc.body" highlight="::vm.highlight[doc.id]" maxlength="10" hkey="body"></field>
+    <field ng-if="doc.test" value="doc.test" highlight="::vm.highlight[doc.test]" maxlength="100" hkey="test"></field>
   </p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -2,7 +2,7 @@
   <!-- show head field linked with a url. -->
   <h3 class="head-field" ng-if="doc.subject"><a ng-href="{{vm.doc.parent_s}}" target="document"
                                                  ng-click="vm.postClickSignal(this, doc.id, $index, doc.score)">
-    <field value="doc.subject" highlight="vm.shortenSubject[doc.id]" maxlength="200" hkey="subject"></field>
+    <field value="doc.shortSub" highlight="vm.shortenSubject[doc.id]" maxlength="200" hkey="subject"></field>
   </a>
   </h3>
   <!-- show head field without a url. -->

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -9,10 +9,9 @@
   <h3 class="head-field" ng-if="!doc.title">
     <field value="doc.id" maxlength="200"></field>
   </h3>
-  <h6><field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="10" hkey="list"></field> : <field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="10" hkey="from"></field></h6>
+  <h6>Sent from:<br><field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>  :  <field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
     <field ng-if="doc.body" value="doc.body" highlight="::vm.highlight[doc.id]" maxlength="10" hkey="body"></field>
   </p>
 </div>
-

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -13,5 +13,7 @@
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
     <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="trimed"></field>
+  </br><button ng-click="seeAll = !seeAll" ng-init="seeAll=false">show full content</button>
+</br><field ng-if="seeAll" value="doc.body" maxlength="10000"></field>
   </p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -12,6 +12,6 @@
   <h6>From:&lt;<field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>&gt;<field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
-    <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="shortbody"></field>
+    <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="trimed"></field>
   </p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -13,7 +13,7 @@
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
     <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="trimed"></field>
-  </br><button ng-click="seeAll = !seeAll" ng-init="seeAll=false">show full content</button>
-</br><field ng-if="seeAll" value="doc.body" maxlength="10000"></field>
   </p>
+<button ng-click="seeAll = !seeAll" ng-init="seeAll=false">{{seeAll && 'hide' || 'full content'}}</button>
+<p class="large-8 xlarge-7 xx-large-6 mail-body"><field ng-if="seeAll" value="doc.body" maxlength="10000"></field></p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -2,7 +2,7 @@
   <!-- show head field linked with a url. -->
   <h3 class="head-field" ng-if="doc.subject"><a ng-href="{{vm.doc.parent_s}}" target="document"
                                                  ng-click="vm.postClickSignal(this, doc.id, $index, doc.score)">
-    <field value="doc.shortSub" highlight="vm.shortenSubject[doc.id]" maxlength="200" hkey="subject"></field>
+    <field value="doc.shortSub" highlight="::vm.shortenSubject[doc.id]" maxlength="200" hkey="subject"></field>
   </a>
   </h3>
   <!-- show head field without a url. -->

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -2,7 +2,7 @@
   <!-- show head field linked with a url. -->
   <h3 class="head-field" ng-if="doc.subject"><a ng-href="{{vm.doc.parent_s}}" target="document"
                                                  ng-click="vm.postClickSignal(this, doc.id, $index, doc.score)">
-    <field value="doc.subject" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="subject"></field>
+    <field value="doc.subject" highlight="vm.shortenSubject[doc.id]" maxlength="200" hkey="subject"></field>
   </a>
   </h3>
   <!-- show head field without a url. -->

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -9,9 +9,9 @@
   <h3 class="head-field" ng-if="!doc.title">
     <field value="doc.id" maxlength="200"></field>
   </h3>
-  <h6>Sent from:<br><field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>  :  <field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
+  <h6>From:&lt;<field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>&gt;<field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
-    <field ng-if="doc.body" value="doc.body" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="shortbody"></field>
+    <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="shortbody"></field>
   </p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -12,6 +12,6 @@
   <h6>Sent from:<br><field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>  :  <field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
-    <field ng-if="doc.test" value="doc.test" highlight="::vm.highlight[doc.test]" maxlength="100" hkey="test"></field>
+    <field ng-if="doc.body" value="doc.body" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="shortbody"></field>
   </p>
 </div>

--- a/client/assets/components/document/document_mail/document_mail.html
+++ b/client/assets/components/document/document_mail/document_mail.html
@@ -12,7 +12,7 @@
   <h6>From:&lt;<field ng-if="doc.list" value="doc.list" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="list"></field>&gt;<field ng-if="doc.from" value="doc.from" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="from"></field></h6>
 
   <p class="large-8 xlarge-7 xx-large-6 mail-body">
-    <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="100" hkey="trimed"></field>
+    <field ng-if="doc.shortbody" value="doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="trimed"></field>
   </p>
 <button ng-click="seeAll = !seeAll" ng-init="seeAll=false">{{seeAll && 'hide' || 'full content'}}</button>
 <p class="large-8 xlarge-7 xx-large-6 mail-body"><field ng-if="seeAll" value="doc.body" maxlength="10000"></field></p>

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -23,14 +23,13 @@
 
   }
 
-  function Controller($sce, SnowplowService, $filter, $log, QueryService) {
+  function Controller($sce, SnowplowService, $filter, $log) {
     'ngInject';
     var vm = this;
 
     activate();
 
     function activate() {
-      vm.queryObject = QueryService.getQueryObject();
       vm.postSignal = SnowplowService.postSignal;
       vm.postClickSignal = SnowplowService.postClickSignal;
       vm.doc = processDocument(vm.doc);

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -34,12 +34,12 @@
       vm.postClickSignal = SnowplowService.postClickSignal;
       vm.doc = processDocument(vm.doc);
       vm.shortenSubject=shortenSubject(vm.highlight);
-      $log.info("see shortenSubject");
-      $log.info(vm.shortenSubject);
     }
 
     function processDocument(doc) {
       //make sure we can display the info
+      doc['shortSub']=doc['subject'].replace(/\s*\(.*?\)\s*/g, '').replace(/\s*\[.*?\]\s*/g, '');
+      doc['shortSub']=$sce.trustAsHtml(doc['shortSub']);
       doc['body'] = $sce.trustAsHtml(doc['body']);
       doc['subject'] = $sce.trustAsHtml(doc['subject']);
       //$log.info(doc['subject']);

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -23,13 +23,17 @@
 
   }
 
-  function Controller($sce, SnowplowService, $filter, $log) {
+  function Controller($sce, SnowplowService, $filter, $log, QueryService) {
     'ngInject';
     var vm = this;
 
     activate();
 
     function activate() {
+      vm.queryObject = QueryService.getQueryObject();
+      $log.info("see Query Obj in document:");
+      $log.info(vm.queryObject);
+
       vm.postSignal = SnowplowService.postSignal;
       vm.postClickSignal = SnowplowService.postClickSignal;
       vm.doc = processDocument(vm.doc);
@@ -38,10 +42,15 @@
     function processDocument(doc) {
       //make sure we can display the info
       $log.info(doc['subject']);
-      doc['body'] = $sce.trustAsHtml(doc['body']);
+      //doc['body'] = $sce.trustAsHtml(doc['body']);
       doc['subject'] = $sce.trustAsHtml(doc['subject']);
       $log.info(doc['subject']);
       doc['id'] = $sce.trustAsHtml(doc['id']);
+      doc['test']=testFunction(doc['body'],vm.queryObject,100,1);
+      $log.info("see output");
+      $log.info(doc['test']);
+      $log.info("see original");
+      $log.info(doc['body']);
       doc.length_lFormatted = $filter('humanizeFilesize')(doc.length_l);
       doc.lastModified_dtFormatted = $filter('date')(doc.lastModified_dt);
       $log.info("see last modified");
@@ -51,6 +60,37 @@
       return doc;
     }
 
+    function testFunction(para,q,len,skip){
+      //$log.info(para);
+      q=q['q'];
+      //$log.info(q);
+      $log.info(para);
+      $log.info(typeof para);
+      var splittedIntoArray=para.split(/[\s,]+/);
+      $log.info("see splitted");
+      $log.info(splittedIntoArray);
+      var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
+      $log.info("check variable");
+      $log.info(containHighlight);
+      $log.info(containHighlight.length);
+      var paraLength=containHighlight.length;
+      //$log.info(paraLength);
+      var max=0;
+      var maxind=0;
+      var i=0;
+      while (i+len<=paraLength){
+        //$log.info("checkpoint");
+        var tmp = containHighlight.slice(i,i+len).reduce((a, b) => a + b, 0);
+        $log.info(tmp);
+        if(tmp>max){
+          max=tmp;
+          maxind=i;
+        }
+        i=i+skip;
+      }
+      return splittedIntoArray.slice(maxind,maxind+len).join(" ");
+
+    }
 
 
   }

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -31,9 +31,6 @@
 
     function activate() {
       vm.queryObject = QueryService.getQueryObject();
-      $log.info("see Query Obj in document:");
-      $log.info(vm.queryObject);
-
       vm.postSignal = SnowplowService.postSignal;
       vm.postClickSignal = SnowplowService.postClickSignal;
       vm.doc = processDocument(vm.doc);
@@ -46,52 +43,9 @@
       doc['subject'] = $sce.trustAsHtml(doc['subject']);
       $log.info(doc['subject']);
       doc['id'] = $sce.trustAsHtml(doc['id']);
-      doc['test']=testFunction(doc['body'],vm.queryObject,100,1);
-      $log.info("see output");
-      $log.info(doc['test']);
-      $log.info("see original");
-      $log.info(doc['body']);
       doc.length_lFormatted = $filter('humanizeFilesize')(doc.length_l);
       doc.lastModified_dtFormatted = $filter('date')(doc.lastModified_dt);
-      $log.info("see last modified");
-      $log.info(doc.lastModified_dtFormatted);
-      $log.info("see doc");
-      $log.info(doc);
       return doc;
     }
-
-    function testFunction(para,q,len,skip){
-      //$log.info(para);
-      q=q['q'];
-      //$log.info(q);
-      $log.info(para);
-      $log.info(typeof para);
-      var splittedIntoArray=para.split(/[\s,]+/);
-      $log.info("see splitted");
-      $log.info(splittedIntoArray);
-      var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
-      $log.info("check variable");
-      $log.info(containHighlight);
-      $log.info(containHighlight.length);
-      var paraLength=containHighlight.length;
-      //$log.info(paraLength);
-      var max=0;
-      var maxind=0;
-      var i=0;
-      while (i+len<=paraLength){
-        //$log.info("checkpoint");
-        var tmp = containHighlight.slice(i,i+len).reduce((a, b) => a + b, 0);
-        $log.info(tmp);
-        if(tmp>max){
-          max=tmp;
-          maxind=i;
-        }
-        i=i+skip;
-      }
-      return splittedIntoArray.slice(maxind,maxind+len).join(" ");
-
-    }
-
-
   }
 })();

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -44,7 +44,14 @@
       doc['id'] = $sce.trustAsHtml(doc['id']);
       doc.length_lFormatted = $filter('humanizeFilesize')(doc.length_l);
       doc.lastModified_dtFormatted = $filter('date')(doc.lastModified_dt);
+      $log.info("see last modified");
+      $log.info(doc.lastModified_dtFormatted);
+      $log.info("see doc");
+      $log.info(doc);
       return doc;
     }
+
+
+
   }
 })();

--- a/client/assets/components/document/document_mail/document_mail.js
+++ b/client/assets/components/document/document_mail/document_mail.js
@@ -26,13 +26,16 @@
   function Controller($sce, SnowplowService, $filter, $log) {
     'ngInject';
     var vm = this;
-
+    vm.shortenSubject={};
     activate();
 
     function activate() {
       vm.postSignal = SnowplowService.postSignal;
       vm.postClickSignal = SnowplowService.postClickSignal;
       vm.doc = processDocument(vm.doc);
+      vm.shortenSubject=shortenSubject(vm.highlight);
+      $log.info("see shortenSubject");
+      $log.info(vm.shortenSubject);
     }
 
     function processDocument(doc) {
@@ -45,5 +48,20 @@
       doc.lastModified_dtFormatted = $filter('date')(doc.lastModified_dt);
       return doc;
     }
+
+    function shortenSubject(highlight){
+      _.each(highlight, function(value,key){
+        if(value['subject']){
+          vm.shortenSubject[key]={'subject':(value['subject']+'').replace(/\s*\(.*?\)\s*/g, '').replace(/\s*\[.*?\]\s*/g, '')};
+        }
+        else{
+          $log.info("no subject in highlight");
+        }
+      });
+      return vm.shortenSubject;
+    }
+
+
+
   }
 })();

--- a/client/assets/components/document/document_website/document_website.html
+++ b/client/assets/components/document/document_website/document_website.html
@@ -29,7 +29,7 @@
 
 
 
-     <field ng-if="vm.doc.shortbody" value="vm.doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="shortbody"></field>
+     <field ng-if="vm.doc.shortbody" value="vm.doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="trimed"></field>
 
              <!-- Other fields -->
 

--- a/client/assets/components/document/document_website/document_website.html
+++ b/client/assets/components/document/document_website/document_website.html
@@ -30,6 +30,8 @@
 
 
      <field ng-if="vm.doc.shortbody" value="vm.doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="trimed"></field>
+   </br><button ng-click="seeAll = !seeAll" ng-init="seeAll=false">show full content</button>
+ </br><field ng-if="seeAll" value="doc.body" maxlength="10000"></field>
 
              <!-- Other fields -->
 

--- a/client/assets/components/document/document_website/document_website.html
+++ b/client/assets/components/document/document_website/document_website.html
@@ -30,11 +30,10 @@
 
 
      <field ng-if="vm.doc.shortbody" value="vm.doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="trimed"></field>
-   </br><button ng-click="seeAll = !seeAll" ng-init="seeAll=false">show full content</button>
- </br><field ng-if="seeAll" value="doc.body" maxlength="10000"></field>
-
              <!-- Other fields -->
-
     </p>
+  <button ng-click="seeAll = !seeAll" ng-init="seeAll=false">{{seeAll && 'hide' || 'full content'}}</button>
+  <p class="large-8 xlarge-7 xx-large-6 mail-body"><field ng-if="seeAll" value="doc.body" maxlength="10000"></field></p>
+
   </div>
 </article>

--- a/client/assets/components/document/document_website/document_website.html
+++ b/client/assets/components/document/document_website/document_website.html
@@ -29,7 +29,7 @@
 
 
 
-     <field ng-if="vm.doc.body" value="vm.doc.body" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="body"></field>
+     <field ng-if="vm.doc.shortbody" value="vm.doc.shortbody" highlight="::vm.highlight[doc.id]" maxlength="200" hkey="shortbody"></field>
 
              <!-- Other fields -->
 

--- a/client/assets/components/documents/documents.html
+++ b/client/assets/components/documents/documents.html
@@ -13,7 +13,6 @@
   <div ng-if="vm.groupedResults" ng-repeat="(key, val) in vm.groupedResults">
     <div ng-repeat="group in val.groups">
       <h3 ng-if="group.groupValue" ng-click="vm.toggleGroupedResults(group.groupValue)">{{group.groupValue}}</h3>
-
       <div ng-repeat="doc in group.doclist.docs" ng-switch="::vm.getDocType(doc)"
            >
         <span ng-switch-when="github"><div ng-include="'/templates/github.html'"></div></span>

--- a/client/assets/components/documents/documents.html
+++ b/client/assets/components/documents/documents.html
@@ -13,8 +13,7 @@
   <div ng-if="vm.groupedResults" ng-repeat="(key, val) in vm.groupedResults">
     <div ng-repeat="group in val.groups">
       <h3 ng-if="group.groupValue" ng-click="vm.toggleGroupedResults(group.groupValue)">{{group.groupValue}}</h3>
-      <div ng-repeat="doc in group.doclist.docs" ng-switch="::vm.getDocType(doc)"
-           >
+      <div ng-repeat="doc in group.doclist.docs" ng-switch="::vm.getDocType(doc)">
         <span ng-switch-when="github"><div ng-include="'/templates/github.html'"></div></span>
         <span ng-switch-when="jira"><div ng-include="'/templates/jira.html'"></div></span>
         <document-mail ng-switch-when="mailing" doc="vm.decorateDocument(doc)" bind="doc"

--- a/client/assets/components/documents/documents.html
+++ b/client/assets/components/documents/documents.html
@@ -6,8 +6,8 @@
                    highlight="vm.highlighting"></document-mail>
     <document-website ng-switch-when="website" doc="vm.decorateDocument(doc)" bind="doc"
                   highlight="vm.highlighting"></document-website>
-    <document-lucid-docs ng-switch-when="lucid-docs" doc="vm.decorateDocument(doc)" bind="doc"
-                  highlight="vm.highlighting"></document-lucid-docs>
+    <document-website ng-switch-when="lucid-docs" doc="vm.decorateDocument(doc)" bind="doc"
+                  highlight="vm.highlighting"></document-website>
 
   </div>
   <div ng-if="vm.groupedResults" ng-repeat="(key, val) in vm.groupedResults">

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -48,8 +48,8 @@
         $log.info(queryObject);
         $log.info("see data");
         $log.info(data);
-
-        data=testFunction(data,queryObject,1,30);
+        data=addShortInDocs(data,queryObject,1,30);
+        data=addShortInHighlight(data,queryObject,1,30);
         $log.info("see data again");
         $log.info(data);
 
@@ -179,22 +179,46 @@
     }
 
 
-    function testFunction(data,q,skip,snippetLen){
+    function addShortInDocs(data,q,skip,snippetLen){
+      q=q['q'];
+      _.each(data.response.docs, function(doc){
+        if(doc['body_display']){
+          var splittedIntoArray=(doc['body_display'][0]).split(/[\s]+/);
+          $log.info(splittedIntoArray);
+          var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
+          $log.info(containHighlight);
+          var paraLength=containHighlight.length;
+          $log.info(paraLength);
+          var max=0;
+          var maxind=0;
+          var i=0;
+          while (i+snippetLen<=paraLength){
+            //$log.info("checkpoint");
+            var tmp = containHighlight.slice(i,i+snippetLen).reduce((a, b) => a + b, 0);
+            if(tmp>max){
+              max=tmp;
+              maxind=i;
+            }
+            i=i+skip;
+          }
+          $log.info("see output obj");
+          $log.info(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
+          doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
+        }
+        else{
+          $log.info("no body_display?!");
+        }
+      });
+      return data;
+    }
+
+
+
+    function addShortInHighlight(data,q,skip,snippetLen){
       q=q['q'];
       _.each(data.highlighting, function(value,key){
         $log.info("see original");
         $log.info(value['body']+'');
-
-        if(value['body']){
-          var para=value['body'];
-        }
-        else{
-          var para=data.
-        }
-
-
-
-
         if(value['body']){
           var splittedIntoArray=(value['body'][0]).split(/[\s]+/);
           $log.info(splittedIntoArray);

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -181,7 +181,8 @@
         _.each(data.response.docs,function(doc){
           if(doc['body']){
             var splittedIntoArray=(doc['body']).split(/[\s]+/);
-            var formedString=splittedIntoArray.join(" ");
+            var re = new RegExp("\-\-\-+","g");
+            var formedString=splittedIntoArray.join(" ").replace(re,"");
             if(formedString.length<snippetLen){
               $log.info(formedString);
               doc['shortbody']=$sce.trustAsHtml(formedString);
@@ -200,7 +201,8 @@
         _.each(data.response.docs, function(doc){
           if(doc['body']){
             var splittedIntoArray=(doc['body']).split(/[\s]+/);
-            var formedString=splittedIntoArray.join(" ");
+            var re = new RegExp("\-\-\-+","g");
+            var formedString=splittedIntoArray.join(" ").replace(re,"");
             var re = new RegExp(q, "gi");
             var res = formedString.match(re);
             var max=0;
@@ -274,7 +276,8 @@
       _.each(data.highlighting, function(value,key){
         if(value['body']){
           var splittedIntoArray=(value['body'][0]).split(/[\s]+/);
-          value['trimed']=[splittedIntoArray.join(" ")+'...'];
+          var re = new RegExp("\-\-\-+","g");
+          value['trimed']=[splittedIntoArray.join(" ").replace(re,"")+'...'];
         }
         else{
           $log.info("not in highlight");

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -45,7 +45,7 @@
         //let's make sure we can track individual query/result pairs by assigning a UUID to each unique query
         queryObject["uuid"] = IDService.generateUUID();
         data=addShortInDocs(data,queryObject['q'],1,30);//not skip, snippet length is 30
-        data=addShortInHighlight(data,queryObject['q'],1,30);//not skip, snippet length is 30
+        data=trimSpaceInHighlight(data);
         vm.docs = parseDocuments(data);
         //add transformed body
         vm.highlighting = parseHighlighting(data);
@@ -209,30 +209,11 @@
 
 
 
-    function addShortInHighlight(data,q,skip,snippetLen){
+    function trimSpaceInHighlight(data){
       _.each(data.highlighting, function(value,key){
         if(value['body']){
           var splittedIntoArray=(value['body'][0]).split(/[\s]+/);
-          var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
-          var paraLength=containHighlight.length;
-          var max=0;
-          var maxind=0;
-          var i=0;
-          while (i+snippetLen<=paraLength){
-            //$log.info("checkpoint");
-            var tmp = containHighlight.slice(i,i+snippetLen).reduce((a, b) => a + b, 0);
-            if(tmp>max){
-              max=tmp;
-              maxind=i;
-            }
-            i=i+skip;
-          }
-          if(i==0){
-            value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")];
-          }
-          else{
-            value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")+'...'];
-          }
+          value['trimed']=[splittedIntoArray.join(" ")+'...'];
         }
         else{
           $log.info("not in highlight");

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -193,7 +193,12 @@
             }
             i=i+skip;
           }
-          doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
+          if(i==0){
+            doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
+          }
+          else{
+            doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")+'...');
+          }
         }
         else{
           $log.info("no body_display?!");
@@ -222,7 +227,12 @@
             }
             i=i+skip;
           }
-          value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")];
+          if(i==0){
+            value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")];
+          }
+          else{
+            value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")+'...'];
+          }
         }
         else{
           $log.info("not in highlight");

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -44,25 +44,11 @@
         var queryObject = QueryService.getQueryObject();
         //let's make sure we can track individual query/result pairs by assigning a UUID to each unique query
         queryObject["uuid"] = IDService.generateUUID();
-
-        $log.info("Query Obj:");
-        $log.info(queryObject);
-        $log.info("see data");
-        $log.info(data);
         data=addShortInDocs(data,queryObject,1,30);
         data=addShortInHighlight(data,queryObject,1,30);
-        $log.info("see data again");
-        $log.info(data);
-
         vm.docs = parseDocuments(data);
-        $log.info("take a look at docs");
-        $log.info(vm.docs);
-
         //add transformed body
-
         vm.highlighting = parseHighlighting(data);
-        $log.info("see what's in highlighting");
-        $log.info(vm.highlighting);
         vm.getDoctype = getDocType;
         $anchorScroll('topOfMainContent');
       });
@@ -194,11 +180,8 @@
       _.each(data.response.docs, function(doc){
         if(doc['body_display']){
           var splittedIntoArray=(doc['body_display'][0]).split(/[\s]+/);
-          $log.info(splittedIntoArray);
           var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
-          $log.info(containHighlight);
           var paraLength=containHighlight.length;
-          $log.info(paraLength);
           var max=0;
           var maxind=0;
           var i=0;
@@ -211,8 +194,6 @@
             }
             i=i+skip;
           }
-          $log.info("see output obj");
-          $log.info(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
           doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
         }
         else{
@@ -227,15 +208,10 @@
     function addShortInHighlight(data,q,skip,snippetLen){
       q=q['q'];
       _.each(data.highlighting, function(value,key){
-        $log.info("see original");
-        $log.info(value['body']+'');
         if(value['body']){
           var splittedIntoArray=(value['body'][0]).split(/[\s]+/);
-          $log.info(splittedIntoArray);
           var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
-          $log.info(containHighlight);
           var paraLength=containHighlight.length;
-          $log.info(paraLength);
           var max=0;
           var maxind=0;
           var i=0;
@@ -248,18 +224,13 @@
             }
             i=i+skip;
           }
-          $log.info("see output");
-          $log.info(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
           value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")];
         }
         else{
-          $log.info("not captured");
+          $log.info("not in highlight");
         }
       });
       return data;
     }
-
-
-
   }
 })();

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -32,7 +32,6 @@
     vm.toggleGroupedResults = toggleGroupedResults;
     vm.decorateDocument = decorateDocument;
     vm.showGroupedResults = {};
-
     activate();
 
     ////////

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -44,8 +44,8 @@
         var queryObject = QueryService.getQueryObject();
         //let's make sure we can track individual query/result pairs by assigning a UUID to each unique query
         queryObject["uuid"] = IDService.generateUUID();
-        data=addShortInDocs(data,queryObject,1,30);
-        data=addShortInHighlight(data,queryObject,1,30);
+        data=addShortInDocs(data,queryObject['q'],1,30);//not skip, snippet length is 30
+        data=addShortInHighlight(data,queryObject['q'],1,30);//not skip, snippet length is 30
         vm.docs = parseDocuments(data);
         //add transformed body
         vm.highlighting = parseHighlighting(data);
@@ -176,7 +176,6 @@
 
 
     function addShortInDocs(data,q,skip,snippetLen){
-      q=q['q'];
       _.each(data.response.docs, function(doc){
         if(doc['body_display']){
           var splittedIntoArray=(doc['body_display'][0]).split(/[\s]+/);
@@ -206,7 +205,6 @@
 
 
     function addShortInHighlight(data,q,skip,snippetLen){
-      q=q['q'];
       _.each(data.highlighting, function(value,key){
         if(value['body']){
           var splittedIntoArray=(value['body'][0]).split(/[\s]+/);

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -46,8 +46,22 @@
         queryObject["uuid"] = IDService.generateUUID();
         $log.info("Query Obj:");
         $log.info(queryObject);
+        $log.info("see data");
+        $log.info(data);
+
+        data=testFunction(data,queryObject,1,30);
+        $log.info("see data again");
+        $log.info(data);
+
         vm.docs = parseDocuments(data);
+        $log.info("take a look at docs");
+        $log.info(vm.docs);
+
+        //add transformed body
+
         vm.highlighting = parseHighlighting(data);
+        $log.info("see what's in highlighting");
+        $log.info(vm.highlighting);
         vm.getDoctype = getDocType;
         $anchorScroll('topOfMainContent');
       });
@@ -163,5 +177,55 @@
       }
       return vm.highlighting;
     }
+
+
+    function testFunction(data,q,skip,snippetLen){
+      q=q['q'];
+      _.each(data.highlighting, function(value,key){
+        $log.info("see original");
+        $log.info(value['body']+'');
+
+        if(value['body']){
+          var para=value['body'];
+        }
+        else{
+          var para=data.
+        }
+
+
+
+
+        if(value['body']){
+          var splittedIntoArray=(value['body'][0]).split(/[\s]+/);
+          $log.info(splittedIntoArray);
+          var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
+          $log.info(containHighlight);
+          var paraLength=containHighlight.length;
+          $log.info(paraLength);
+          var max=0;
+          var maxind=0;
+          var i=0;
+          while (i+snippetLen<=paraLength){
+            //$log.info("checkpoint");
+            var tmp = containHighlight.slice(i,i+snippetLen).reduce((a, b) => a + b, 0);
+            if(tmp>max){
+              max=tmp;
+              maxind=i;
+            }
+            i=i+skip;
+          }
+          $log.info("see output");
+          $log.info(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
+          value['shortbody']=[splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")];
+        }
+        else{
+          $log.info("not captured");
+        }
+      });
+      return data;
+    }
+
+
+
   }
 })();

--- a/client/assets/components/documents/documents.js
+++ b/client/assets/components/documents/documents.js
@@ -184,11 +184,9 @@
             var re = new RegExp("\-\-\-+","g");
             var formedString=splittedIntoArray.join(" ").replace(re,"");
             if(formedString.length<snippetLen){
-              $log.info(formedString);
               doc['shortbody']=$sce.trustAsHtml(formedString);
             }
             else{
-              $log.info(formedString.slice(0,snippetLen)+'...');
               doc['shortbody']=$sce.trustAsHtml(formedString.slice(0,snippetLen)+'...');
             }
           }
@@ -233,44 +231,6 @@
   }
       return data;
     }
-
-
-
-
-/*
-    function addShortInDocs(data,q,skip,snippetLen){
-      _.each(data.response.docs, function(doc){
-        if(doc['body_display']){
-          var splittedIntoArray=(doc['body_display'][0]).split(/[\s]+/);
-          var containHighlight=splittedIntoArray.map(a=>a.toLowerCase().includes(q.toLowerCase()));
-          var paraLength=containHighlight.length;
-          var max=0;
-          var maxind=0;
-          var i=0;
-          while (i+snippetLen<=paraLength){
-            //$log.info("checkpoint");
-            var tmp = containHighlight.slice(i,i+snippetLen).reduce((a, b) => a + b, 0);
-            if(tmp>max){
-              max=tmp;
-              maxind=i;
-            }
-            i=i+skip;
-          }
-          if(i==0){
-            doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" "));
-          }
-          else{
-            doc['shortbody']=$sce.trustAsHtml(splittedIntoArray.slice(maxind,maxind+snippetLen).join(" ")+'...');
-          }
-        }
-        else{
-          $log.info("no body_display?!");
-        }
-      });
-      return data;
-    }
-*/
-
 
     function trimSpaceInHighlight(data){
       _.each(data.highlighting, function(value,key){


### PR DESCRIPTION
I mainly did three things in these code. 
1 show author more nicely
2 make content less verbose
    a. added in every doc of data.response.docs an attribute called shortbody, which is a short version of body
    b. added in every data.highlighting[doc.id] an attribute called shortbody, which is a short version of body
Having both a and b may be inefficient in that it equals doing the same shortening process twice for every shown data. However, since they are indexed in two different ways(one is indexed by doc.id, one is indexed by numbers from 0), it seems not easy to do it much more efficiently. 

For the shortening, the basic idea is splitting the string into arrays, and then moving from the beginning and evaluating a slice of the array, that is, counting how many key words is included. The output should be the snippet with the most key words. Parameter ‘skip’ is used to control the speed of the searching. It means how many elements to skip after evaluating one slice of the array. The length of the snippet should be the ideal length to be shown in the view. It is controlled by parameter snippetLen. 

3 removed parenthesis like ‘[JIRA]’ in subjects to make it look better(only for mailing list)
