### PR TITLE
Date Formats and more MBox Config

### DIFF
--- a/searchhub-fusion-plugins/src/main/java/com/lucidworks/apollo/pipeline/index/stages/searchhub/mail/MBoxParsingStage.java
+++ b/searchhub-fusion-plugins/src/main/java/com/lucidworks/apollo/pipeline/index/stages/searchhub/mail/MBoxParsingStage.java
@@ -37,7 +37,8 @@ public class MBoxParsingStage extends IndexStage<MBoxParsingStageConfig> {
     logger.info("running MBoxParsingStage on " + doc.getId() + " (which has " + doc.getAllFieldNames().size() + " fields )");
 
     // TODO: should be cached for better throughput
-    MimeMailParser parser = new MimeMailParser();
+    MBoxParsingStageConfig config = getConfiguration();
+    MimeMailParser parser = new MimeMailParser(config.getIdPattern(), config.getBotEmailPatterns());
     PipelineDocument newDoc = parser.parse(doc);
     if (newDoc == null) {
       return;

--- a/searchhub-fusion-plugins/src/main/java/com/lucidworks/apollo/pipeline/index/stages/searchhub/mail/MBoxParsingStageConfig.java
+++ b/searchhub-fusion-plugins/src/main/java/com/lucidworks/apollo/pipeline/index/stages/searchhub/mail/MBoxParsingStageConfig.java
@@ -1,25 +1,102 @@
 package com.lucidworks.apollo.pipeline.index.stages.searchhub.mail;
 // NOTE: Fusion ObjectMapper scans sub-packages of com.lucidworks.apollo.pipeline.index.stages for these configs!
 
+import com.google.common.collect.Lists;
 import com.lucidworks.apollo.pipeline.StageConfig;
+import com.lucidworks.apollo.pipeline.schema.Annotations;
+import com.lucidworks.apollo.pipeline.schema.Annotations.SchemaProperty;
+import com.lucidworks.apollo.pipeline.schema.Annotations.ArrayProperty;
 import com.lucidworks.apollo.pipeline.schema.Annotations.Schema;
+import com.lucidworks.apollo.pipeline.schema.UIHints;
+import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonCreator;
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.annotate.JsonTypeName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
 
 
 @JsonTypeName(MBoxParsingStageConfig.TYPE)
 @Schema(
-  type = MBoxParsingStageConfig.TYPE,
-  title = "Mailbox Parsing Stage",
-  description = "This stage does custom mailbox parsing"
+        type = MBoxParsingStageConfig.TYPE,
+        title = "Mailbox Parsing Stage",
+        description = "This stage does custom mailbox parsing"
 )
 public class MBoxParsingStageConfig extends StageConfig {
-
+  private static Logger log = LoggerFactory.getLogger(MBoxParsingStageConfig.class);
   public static final String TYPE = "mbox-parsing";
 
+  @SchemaProperty(title = "Bot Email Patterns", description = "These patterns will be applied to the From Email address to determine if the email is from a bot",
+          hints = UIHints.ADVANCED)
+  @ArrayProperty
+  private final List<String> botEmails;
+
+  @SchemaProperty(title = "Id Pattern", required = true,
+          description = "The pattern to be applied to the Id to determine if this is a proper raw MBox Id from mod_mbox",
+          hints = {UIHints.ADVANCED}, defaultValue = ".*/\\d{6}\\.mbox/raw/%3[Cc].*%3[eE]$")
+  private final String idPatternStr;
+
+  @JsonIgnore
+  private final List<Pattern> botEmailPatterns;
+
+  @JsonIgnore
+  private final Pattern idPattern;
+
   @JsonCreator
-  public MBoxParsingStageConfig(@JsonProperty("id") String id) {
+  public MBoxParsingStageConfig(@JsonProperty("id") String id,
+                                @JsonProperty("idPatternStr") String idPatternStr,
+                                @JsonProperty("botEmails") List<String> botEmails
+  ) {
     super(id);
+    log.info("Id Pattern: {}, botEmails: {}", idPatternStr, botEmails);
+    this.idPatternStr = idPatternStr;
+
+    if (idPatternStr != null) {
+      idPattern = Pattern.compile(idPatternStr);
+    } else {
+      idPattern = Pattern.compile(".*/\\d{6}\\.mbox/raw/%3[Cc].*%3[eE]$");
+    }
+    if (botEmails == null || botEmails.isEmpty()) {
+      this.botEmails = Lists.newArrayList(
+              ".*buildbot@.*",
+              ".*git@.*",
+              ".*hudson@.*",
+              // way of filtering code reviews too?
+              ".*jenkins@.*",
+              ".*jira@.*",
+              ".*subversion@.*",
+              ".*svn@.*");
+    } else {
+      this.botEmails = Collections.unmodifiableList(botEmails);
+    }
+    botEmailPatterns = new ArrayList<>(this.botEmails.size());
+    for (String botEmail : this.botEmails) {
+      botEmailPatterns.add(Pattern.compile(botEmail));
+    }
+  }
+
+  @JsonProperty("botEmails")
+  public List<String> getBotEmails() {
+    return botEmails;
+  }
+
+  @JsonProperty("idPatternStr")
+  public String getIdPatternStr() {
+    return idPatternStr;
+  }
+
+  @JsonIgnore
+  public List<Pattern> getBotEmailPatterns() {
+    return botEmailPatterns;
+  }
+
+  @JsonIgnore
+  public Pattern getIdPattern() {
+    return idPattern;
   }
 }

--- a/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/connectors/mail/handler/MailUrlId.java
+++ b/searchhub-fusion-plugins/src/main/java/com/lucidworks/searchhub/connectors/mail/handler/MailUrlId.java
@@ -21,7 +21,6 @@ import java.util.List;
  * full messageId: <F9210543-78B0-47ED-BD6B-0E850CC08774@apache.org>
  */
 public class MailUrlId {
-  private static final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMM");
 
   private final String url;
   private final String messageId;
@@ -45,6 +44,7 @@ public class MailUrlId {
     Date tempDate;
     approxDateStr = parts.get(numParts - 3);
     try {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyyMM");
       tempDate = sdf.parse(approxDateStr);
     } catch (ParseException e) {
       tempDate = new Date();

--- a/searchhub-fusion-plugins/src/main/scala/com/lucidworks/searchhub/analytics/MailMessage.scala
+++ b/searchhub-fusion-plugins/src/main/scala/com/lucidworks/searchhub/analytics/MailMessage.scala
@@ -22,7 +22,7 @@ case class MailMessage(id: String, project: String, list: String, listType: Stri
 object MailMessage {
 
   def fromRawString(id: String, contents: String): Option[MailMessage] = {
-    val mailParser = new MimeMailParser
+    val mailParser = new MimeMailParser//TODO: fix this to take in configurable patterns like the real stage does
     val doc = new PipelineDocument(id)
     doc.setField("_raw_content_", contents.getBytes)
     val parsedDocOpt = try {

--- a/searchhub-fusion-plugins/src/test/java/com/lucidworks/searchhub/connectors/mail/handler/MailTest.java
+++ b/searchhub-fusion-plugins/src/test/java/com/lucidworks/searchhub/connectors/mail/handler/MailTest.java
@@ -77,6 +77,84 @@ public class MailTest {
     Assert.assertEquals("2014-06-25T08:42:36Z", dateStr);
   }
 
+  @Test
+  public void testDates2() throws Exception {
+    MimeMailParser parser = new MimeMailParser();
+    PipelineDocument doc = new PipelineDocument("http://asfmail.lucidworks.io/mail_files/ignite-dev/201411.mbox/raw/%3CCA+0=VoWBdyOM+rPeFYUNT-HxPE8FhimaP6BkfnaK2VnhyEzPTA@mail.gmail.com%3E");
+    doc.addField(MimeMailParser.RAW_CONTENT, JIRA_ACCOUNTS.getBytes());
+    PipelineDocument newDoc = parser.parse(doc);
+    String dateStr = (String) newDoc.getFieldValues(MimeMailParser.FIELD_SENT_DATE).get(0);
+    Assert.assertEquals("2014-11-14T17:53:00Z", dateStr);
+  }
+
+  public static final String JIRA_ACCOUNTS = "From dev-return-63-apmail-ignite-dev-archive=ignite.apache.org@ignite.incubator.apache.org  Fri Nov 14 17:54:53 2014\n" +
+          "Return-Path: <dev-return-63-apmail-ignite-dev-archive=ignite.apache.org@ignite.incubator.apache.org>\n" +
+          "X-Original-To: apmail-ignite-dev-archive@minotaur.apache.org\n" +
+          "Delivered-To: apmail-ignite-dev-archive@minotaur.apache.org\n" +
+          "Received: from mail.apache.org (hermes.apache.org [140.211.11.3])\n" +
+          "\tby minotaur.apache.org (Postfix) with SMTP id 5E8E1F7DB\n" +
+          "\tfor <apmail-ignite-dev-archive@minotaur.apache.org>; Fri, 14 Nov 2014 17:54:53 +0000 (UTC)\n" +
+          "Received: (qmail 15502 invoked by uid 500); 14 Nov 2014 17:54:53 -0000\n" +
+          "Delivered-To: apmail-ignite-dev-archive@ignite.apache.org\n" +
+          "Received: (qmail 15472 invoked by uid 500); 14 Nov 2014 17:54:53 -0000\n" +
+          "Mailing-List: contact dev-help@ignite.incubator.apache.org; run by ezmlm\n" +
+          "Precedence: bulk\n" +
+          "List-Help: <mailto:dev-help@ignite.incubator.apache.org>\n" +
+          "List-Unsubscribe: <mailto:dev-unsubscribe@ignite.incubator.apache.org>\n" +
+          "List-Post: <mailto:dev@ignite.incubator.apache.org>\n" +
+          "List-Id: <dev.ignite.incubator.apache.org>\n" +
+          "Reply-To: dev@ignite.incubator.apache.org\n" +
+          "Delivered-To: mailing list dev@ignite.incubator.apache.org\n" +
+          "Received: (qmail 15461 invoked by uid 99); 14 Nov 2014 17:54:52 -0000\n" +
+          "Received: from athena.apache.org (HELO athena.apache.org) (140.211.11.136)\n" +
+          "    by apache.org (qpsmtpd/0.29) with ESMTP; Fri, 14 Nov 2014 17:54:52 +0000\n" +
+          "X-ASF-Spam-Status: No, hits=1.5 required=5.0\n" +
+          "\ttests=HTML_MESSAGE,RCVD_IN_DNSWL_LOW,SPF_PASS\n" +
+          "X-Spam-Check-By: apache.org\n" +
+          "Received-SPF: pass (athena.apache.org: domain of dsetrakyan@gridgain.com designates 74.125.82.54 as permitted sender)\n" +
+          "Received: from [74.125.82.54] (HELO mail-wg0-f54.google.com) (74.125.82.54)\n" +
+          "    by apache.org (qpsmtpd/0.29) with ESMTP; Fri, 14 Nov 2014 17:54:47 +0000\n" +
+          "Received: by mail-wg0-f54.google.com with SMTP id n12so19981496wgh.13\n" +
+          "        for <dev@ignite.incubator.apache.org>; Fri, 14 Nov 2014 09:53:41 -0800 (PST)\n" +
+          "X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;\n" +
+          "        d=1e100.net; s=20130820;\n" +
+          "        h=x-gm-message-state:mime-version:from:date:message-id:subject:to\n" +
+          "         :content-type;\n" +
+          "        bh=UiHus75Dfnr4FKo1gKpFuUyh4zBt8HP0Oo/ytk+ZdV8=;\n" +
+          "        b=aqWEqk+DXkNrYPddUcXRSXxGqPtzcwtFHpDTnNcsG5fT/KaHkrm2psHo91seWn0ANY\n" +
+          "         iF6zk3gOY3By+5x6XaXkNkHLaSJBsD9Kvp593rMNgcKeLvzCbNYI4OS/YDS/qrNyvarT\n" +
+          "         eBOMB6cw9zWvdpiS3qJkGfaeRk8J7PcEYlo/o1mI64zhkNyRmGVPQr1LHVyM6vo0+dXR\n" +
+          "         zeLLljV15Vq3hvLtdAnbl3PedDUGJz2ABOWQmOf/SOq3ZXhN+zkEvIM59ZARiqqq4ZCh\n" +
+          "         uILr4cdQdowiyn2BUGJao4u+4kC8Q4Zyunn/goNsKorRggPWjgFpehsJrjo0FSNDaEGN\n" +
+          "         3MqQ==\n" +
+          "X-Gm-Message-State: ALoCoQkqn6vnXrnRCmJlAE7fsT79Y2MgeKgu7YIfwBDFIi6ZirpHCvICQcCKntHoqOmk1cgzuoTh\n" +
+          "X-Received: by 10.180.150.138 with SMTP id ui10mr9813288wib.32.1415987621526;\n" +
+          " Fri, 14 Nov 2014 09:53:41 -0800 (PST)\n" +
+          "MIME-Version: 1.0\n" +
+          "Received: by 10.194.51.69 with HTTP; Fri, 14 Nov 2014 09:53:00 -0800 (PST)\n" +
+          "From: Dmitriy Setrakyan <dsetrakyan@gridgain.com>\n" +
+          "Date: Fri, 14 Nov 2014 09:53:00 -0800\n" +
+          "Message-ID: <CA+0=VoWBdyOM+rPeFYUNT-HxPE8FhimaP6BkfnaK2VnhyEzPTA@mail.gmail.com>\n" +
+          "Subject: Jira accounts\n" +
+          "To: dev@ignite.incubator.apache.org\n" +
+          "Content-Type: multipart/alternative; boundary=001a11c3fb20301b140507d54fd9\n" +
+          "X-Virus-Checked: Checked by ClamAV on apache.org\n" +
+          "\n" +
+          "--001a11c3fb20301b140507d54fd9\n" +
+          "Content-Type: text/plain; charset=UTF-8\n" +
+          "\n" +
+          "Hi,\n" +
+          "\n" +
+          "I would like to ask everyone on the committer list to create a Jira account:\n" +
+          "https://issues.apache.org/jira/browse/IGNITE\n" +
+          "\n" +
+          "I am beginning to file tickets and will be assigning them within the main\n" +
+          "committers.\n" +
+          "\n" +
+          "Thanks,\n" +
+          "\n" +
+          "--001a11c3fb20301b140507d54fd9--\n";
+
   public static final String SPARK = "From user-return-10156-apmail-spark-user-archive=spark.apache.org@spark.apache.org  Wed Jun 25 08:43:03 2014\n" +
           "Return-Path: <user-return-10156-apmail-spark-user-archive=spark.apache.org@spark.apache.org>\n" +
           "X-Original-To: apmail-spark-user-archive@minotaur.apache.org\n" +


### PR DESCRIPTION
This PR does two things:
1. Moves the MBoxStage configuration of id patterns out to the stage config so that it is usable in more ways 
2. Moves DateFormat to thread local instances to eliminate #45 
