### PR TITLE
Adding three new sitesearch query profiles and the corresponding pipelines

### DIFF
--- a/python/bootstrap.py
+++ b/python/bootstrap.py
@@ -139,7 +139,7 @@ def setup_projects(backend):
   for file in project_files: #TODO: what's the python way here?
     print ("Creating Project for %s" % file)
     project = json.load(open(join("./project_config", file)))
-    print("Bootstraping configs for %s..." % project["name"])
+    print("Bootstrapping configs for %s..." % project["name"])
     #create the data sources
     datasources = []
     (twitter_config, jira_config, mailbox_configs, wiki_configs, website_configs, github_configs, stack_configs) = backend.create_or_update_datasources(project)
@@ -275,7 +275,9 @@ if cmd_args.create_collections or create_all:
 if cmd_args.create_pipelines or create_all:
   setup_pipelines(backend)
   backend.create_query_profile(lucidfind_collection_id, "lucidfind-default", "lucidfind-default")
-
+  backend.create_query_profile(lucidfind_collection_id, "site-search-blog", "site-search-blog")
+  backend.create_query_profile(lucidfind_collection_id, "site-search-documentation", "site-search-documentation")
+  backend.create_query_profile(lucidfind_collection_id, "site-search-support", "site-search-support")
 
 if cmd_args.create_taxonomy or create_all:
   setup_taxonomy(backend, lucidfind_collection_id)

--- a/python/fusion_config/query_site_search_blog_pipeline.json
+++ b/python/fusion_config/query_site_search_blog_pipeline.json
@@ -1,0 +1,25 @@
+{
+  "id" : "site-search-blog",
+  "stages" : [ {
+    "type" : "set-params",
+    "id" : "47fmz1dn13yc01wcdi",
+    "params" : [ {
+      "key" : "fq",
+      "value" : "_lw_data_source_s=website-lucidworks-lucidworks-website",
+      "policy" : "append"
+    } ],
+    "type" : "set-params",
+    "skip" : false,
+    "label" : "set-params"
+  }, {
+    "type" : "solr-query",
+    "id" : "uft581ubvcth85mi",
+    "allowedRequestHandlers" : [ ],
+    "httpMethod" : "POST",
+    "allowFederatedSearch" : false,
+    "type" : "solr-query",
+    "skip" : false,
+    "label" : "solr-query"
+  } ],
+  "properties" : { }
+}

--- a/python/fusion_config/query_site_search_documentation_pipeline.json
+++ b/python/fusion_config/query_site_search_documentation_pipeline.json
@@ -1,0 +1,44 @@
+{
+  "id" : "site-search-documentation",
+  "stages" : [ {
+    "type" : "facet",
+    "id" : "6v3va7o48epzaor",
+    "fieldFacets" : [ {
+      "field" : "productVersion",
+      "minCount" : 1,
+      "missing" : false
+    }, {
+      "field" : "productName",
+      "minCount" : 1,
+      "missing" : false
+    } ],
+    "type" : "facet",
+    "skip" : false,
+    "label" : "facet"
+  }, {
+    "type" : "set-params",
+    "id" : "pwp7dw5osmjz6w29",
+    "params" : [ {
+      "key" : "fq",
+      "value" : "_lw_data_source_s:website-lucidworks-lucidworks-docs-website",
+      "policy" : "append"
+    }, {
+      "key" : "fq",
+      "value" : "productName:fusion",
+      "policy" : "append"
+    } ],
+    "type" : "set-params",
+    "skip" : false,
+    "label" : "set-params"
+  }, {
+    "type" : "solr-query",
+    "id" : "fy9epi3g56v5597ldi",
+    "allowedRequestHandlers" : [ ],
+    "httpMethod" : "POST",
+    "allowFederatedSearch" : false,
+    "type" : "solr-query",
+    "skip" : false,
+    "label" : "solr-query"
+  } ],
+  "properties" : { }
+}

--- a/python/fusion_config/query_site_search_support_pipeline.json
+++ b/python/fusion_config/query_site_search_support_pipeline.json
@@ -1,0 +1,25 @@
+{
+  "id" : "site-search-support",
+  "stages" : [ {
+    "type" : "set-params",
+    "id" : "059v2z9gfstuo9a4i",
+    "params" : [ {
+      "key" : "fq",
+      "value" : "_lw_data_source_s:website-lucidworks-lucidworks-knowledge-base-website",
+      "policy" : "append"
+    } ],
+    "type" : "set-params",
+    "skip" : false,
+    "label" : "set-params"
+  }, {
+    "type" : "solr-query",
+    "id" : "9zdgtw15xwwomvx6r",
+    "allowedRequestHandlers" : [ ],
+    "httpMethod" : "POST",
+    "allowFederatedSearch" : false,
+    "type" : "solr-query",
+    "skip" : false,
+    "label" : "solr-query"
+  } ],
+  "properties" : { }
+}


### PR DESCRIPTION
In preparation for the new sitesearch, I've created the necessary profiles and pipelines.

The blog pipeline is filtering to Lucidworks website datasource only.
The documentation pipeline is filtering only the "Fusion" product, which might be good enough. I also include the product version facet in there, as well as the productname facet in case we want to include other product lines.
The support pipeline is filtering to knowledge base datasource only.