### PR TITLE
changed and removed unused searchhub variable.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ task checkRequiredProperties() {
   if (!System.getenv("FUSION_HOME")) {
     throw new GradleException('missing FUSION_HOME. Configure in myenv.sh per the README.txt')
   } else {
-    println("Search Hub Fusion location set to $searchhubFusionHome")
+    println("Search Hub Fusion location set to" + System.getenv("FUSION_HOME"))
   }
 }
 checkRequiredProperties


### PR DESCRIPTION
Before this change build broke with the following exception:

ubuntu@:~/searchhub$ ./gradlew deployLibs

FAILURE: Build failed with an exception.

* Where:
Build file '/home/ubuntu/searchhub/build.gradle' line: 88

* What went wrong:
A problem occurred evaluating root project 'searchhub'.
> Could not find property 'searchhubFusionHome' on task ':checkRequiredProperties'.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED
